### PR TITLE
Update CA certificates when building container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=${BUILDPLATFORM} ubuntu:18.04
 
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get install -y make ca-certificates
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Trying to build a golang application in a packaging script got some x509
errors because the ca-certificates were not up to date. This should
hopefully fix that